### PR TITLE
Update sdk to 6.5.0

### DIFF
--- a/alarm-handler-archetype/pom.xml
+++ b/alarm-handler-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.alarm-handler</artifactId>

--- a/alarm-handler-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/alarm-handler-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/alarm-handler-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/alarm-handler-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
     </properties>
 
@@ -22,10 +23,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -36,6 +37,12 @@
             <groupId>se.curity.identityserver</groupId>
             <artifactId>identityserver.sdk</artifactId>
             <version>${project.curityVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/alarm-handler-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/alarm-handler-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-alarm-handler
 pluginName=HelloWorldAlarmHandler
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/authentication-action-archetype/pom.xml
+++ b/authentication-action-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.authentication-action</artifactId>

--- a/authentication-action-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/authentication-action-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/authentication-action-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/authentication-action-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
     </properties>
 
@@ -22,10 +23,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -36,6 +37,12 @@
             <groupId>se.curity.identityserver</groupId>
             <artifactId>identityserver.sdk</artifactId>
             <version>${project.curityVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/authentication-action-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/authentication-action-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-authentication-action
 pluginName=HelloWorldAction
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/authenticator-archetype/pom.xml
+++ b/authenticator-archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.authenticator</artifactId>

--- a/authenticator-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/authenticator-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/authenticator-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/authenticator-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
     </properties>
 
@@ -22,10 +23,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -36,6 +37,12 @@
             <groupId>se.curity.identityserver</groupId>
             <artifactId>identityserver.sdk</artifactId>
             <version>${project.curityVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/authenticator-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/authenticator-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-authenticator
 pluginName=HelloWorld
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/claims-provider-archetype/pom.xml
+++ b/claims-provider-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.claims-provider</artifactId>

--- a/claims-provider-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/claims-provider-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/claims-provider-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/claims-provider-archetype/src/main/resources/archetype-resources/pom.xml
@@ -22,10 +22,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/claims-provider-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/claims-provider-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-claims-provider
 pluginName=HelloWorldClaimsProvider
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/consentor-archetype/pom.xml
+++ b/consentor-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.consentor</artifactId>

--- a/consentor-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/consentor-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/consentor-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/consentor-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
     </properties>
 
@@ -22,10 +23,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/consentor-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/consentor-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-consentor
 pluginName=HelloWorldConsentor
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/data-access-provider-archetype/pom.xml
+++ b/data-access-provider-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.data-access-provider</artifactId>

--- a/data-access-provider-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/data-access-provider-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/data-access-provider-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/data-access-provider-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
     </properties>
 
@@ -22,10 +23,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/data-access-provider-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/data-access-provider-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-data-access-provider
 pluginName=HelloWorldDataAccessProvider
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/email-sender-archetype/pom.xml
+++ b/email-sender-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.email-sender</artifactId>

--- a/email-sender-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/email-sender-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/email-sender-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/email-sender-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
     </properties>
 
@@ -22,10 +23,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -36,6 +37,12 @@
             <groupId>se.curity.identityserver</groupId>
             <artifactId>identityserver.sdk</artifactId>
             <version>${project.curityVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/email-sender-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/email-sender-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-email-sender
 pluginName=HelloWorldEmailSender
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/event-listener-archetype/pom.xml
+++ b/event-listener-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.event-listener</artifactId>

--- a/event-listener-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/event-listener-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/event-listener-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/event-listener-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
     </properties>
 
@@ -22,10 +23,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -36,6 +37,12 @@
             <groupId>se.curity.identityserver</groupId>
             <artifactId>identityserver.sdk</artifactId>
             <version>${project.curityVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/event-listener-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/event-listener-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-event-listener
 pluginName=HelloWorldEventListener
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-alarm-handler-archetype/pom.xml
+++ b/kotlin-alarm-handler-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-alarm-handler</artifactId>

--- a/kotlin-alarm-handler-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-alarm-handler-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-alarm-handler-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-alarm-handler-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-alarm-handler-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-alarm-handler-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-alarm-handler
 pluginName=HelloWorldAlarmHandler
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-authentication-action-archetype/pom.xml
+++ b/kotlin-authentication-action-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-authentication-action</artifactId>

--- a/kotlin-authentication-action-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-authentication-action-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-authentication-action-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-authentication-action-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-authentication-action-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-authentication-action-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-kotlin-hello-world-authentication-action
 pluginName=KotlinHelloWorldAction
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-authenticator-archetype/pom.xml
+++ b/kotlin-authenticator-archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-authenticator</artifactId>

--- a/kotlin-authenticator-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-authenticator-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-authenticator-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-authenticator-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-authenticator-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-authenticator-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-kotlin-hello-world-authenticator
 pluginName=KotlinHelloWorld
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-claims-provider-archetype/pom.xml
+++ b/kotlin-claims-provider-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-claims-provider</artifactId>

--- a/kotlin-claims-provider-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-claims-provider-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-claims-provider-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-claims-provider-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-claims-provider-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-claims-provider-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-kotlin-hello-world-claims-provider
 pluginName=HelloWorldKotlinClaimsProvider
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-consentor-archetype/pom.xml
+++ b/kotlin-consentor-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-consentor</artifactId>

--- a/kotlin-consentor-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-consentor-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-consentor-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-consentor-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-consentor-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-consentor-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-kotlin-hello-world-consentor
 pluginName=HelloWorldKotlinConsentor
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-data-access-provider-archetype/pom.xml
+++ b/kotlin-data-access-provider-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-data-access-provider</artifactId>

--- a/kotlin-data-access-provider-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-data-access-provider-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-data-access-provider-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-data-access-provider-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-data-access-provider-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-data-access-provider-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-kotlin-hello-world-data-access-provider
 pluginName=HelloWorldKotlinDataAccessProvider
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-email-sender-archetype/pom.xml
+++ b/kotlin-email-sender-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-email-sender</artifactId>

--- a/kotlin-email-sender-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-email-sender-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-email-sender-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-email-sender-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-email-sender-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-email-sender-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-kotlin-hello-world-email-sender
 pluginName=HelloWorldKotlinEmailSender
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-event-listener-archetype/pom.xml
+++ b/kotlin-event-listener-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-event-listener</artifactId>

--- a/kotlin-event-listener-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-event-listener-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-event-listener-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-event-listener-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-event-listener-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-event-listener-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-kotlin-hello-world-event-listener
 pluginName=HelloWorldKotlinEventListener
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-oauth-authenticator-archetype/pom.xml
+++ b/kotlin-oauth-authenticator-archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-oauth-authenticator</artifactId>

--- a/kotlin-oauth-authenticator-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-oauth-authenticator-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-oauth-authenticator-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-oauth-authenticator-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-oauth-authenticator-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-oauth-authenticator-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity.oauth
 artifactId=example-curity-kotlin-hello-world-oauth-authenticator
 pluginName=HelloKotlinOAuthWorld
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-signing-consentor-archetype/pom.xml
+++ b/kotlin-signing-consentor-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-signing-consentor</artifactId>

--- a/kotlin-signing-consentor-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-signing-consentor-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-signing-consentor-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-signing-consentor-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-signing-consentor-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-signing-consentor-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-kotlin-hello-world-signing-consentor
 pluginName=HelloWorldKotlinSigningConsentor
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/kotlin-sms-sender-archetype/pom.xml
+++ b/kotlin-sms-sender-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.kotlin-sms-sender</artifactId>

--- a/kotlin-sms-sender-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kotlin-sms-sender-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/kotlin-sms-sender-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-sms-sender-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
     </properties>
 
     <build>
@@ -54,6 +55,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${project.slf4jVersion}</version>
@@ -61,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/kotlin-sms-sender-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-sms-sender-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-kotlin-hello-world-sms-sender
 pluginName=HelloWorldKotlinSMSSender
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/oauth-authenticator-archetype/pom.xml
+++ b/oauth-authenticator-archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.oauth-authenticator</artifactId>

--- a/oauth-authenticator-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/oauth-authenticator-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/oauth-authenticator-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/oauth-authenticator-archetype/src/main/resources/archetype-resources/pom.xml
@@ -20,10 +20,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/oauth-authenticator-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/oauth-authenticator-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity.oauth
 artifactId=example-curity-hello-world-oauth-authenticator
 pluginName=HelloOAuthWorld
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.curity</groupId>
     <artifactId>identityserver.plugins.archetypes</artifactId>
-    <version>2.3.0</version>
+    <version>2.4.0</version>
     
     <name>Curity Plug-in Archetypes</name>
     <description>Archetypes that can generate code for the various kinds of plug-ins supported by the Curity Identity Server</description>
@@ -21,6 +21,12 @@
             <email>travis.spencer@curity.io</email>
             <organization>Curity AB</organization>
             <organizationUrl>https://curity.io</organizationUrl>
+        </developer>
+        <developer>
+            <name>Michael Bornholdt Nielsen</name>
+            <email>michaelbornholdtnielsen@gmail.com</email>
+            <organization>JarryDk</organization>
+            <organizationUrl>https://www.jarry.dk</organizationUrl>
         </developer>
     </developers>
     <scm>

--- a/signing-consentor-archetype/pom.xml
+++ b/signing-consentor-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.signing-consentor</artifactId>

--- a/signing-consentor-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/signing-consentor-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/signing-consentor-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/signing-consentor-archetype/src/main/resources/archetype-resources/pom.xml
@@ -22,10 +22,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/signing-consentor-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/signing-consentor-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-signing-consentor
 pluginName=HelloWorldSigningConsentor
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0

--- a/sms-sender-archetype/pom.xml
+++ b/sms-sender-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.curity</groupId>
         <artifactId>identityserver.plugins.archetypes</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>identityserver.plugins.archetypes.sms-sender</artifactId>

--- a/sms-sender-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/sms-sender-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,7 +10,7 @@
         </requiredProperty>
         <requiredProperty key="pluginName"/>
         <requiredProperty key="curitySdkVersion">
-            <defaultValue>6.1.0</defaultValue>
+            <defaultValue>6.5.0</defaultValue>
         </requiredProperty>
     </requiredProperties>
 

--- a/sms-sender-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/sms-sender-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>${curitySdkVersion}</project.curityVersion>
+        <project.hibernateValidatorVersion>6.2.0.CR1</project.hibernateValidatorVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
     </properties>
 
@@ -22,10 +23,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -36,6 +37,12 @@
             <groupId>se.curity.identityserver</groupId>
             <artifactId>identityserver.sdk</artifactId>
             <version>${project.curityVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${project.hibernateValidatorVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/sms-sender-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/sms-sender-archetype/src/test/resources/projects/basic/archetype.properties
@@ -3,4 +3,4 @@ version=1.0.0-SNAPSHOT
 groupId=com.example.curity
 artifactId=example-curity-hello-world-sms-sender
 pluginName=HelloWorldSMSSender
-curitySdkVersion=6.1.0
+curitySdkVersion=6.5.0


### PR DESCRIPTION
Bump version of maven-archetypes to 2.4.0
Add org.hibernate.validator:hibernate-validator:6.2.0.CR1 provided scope
org.apache.maven.plugins:maven-compiler-plugin  upgraded to 3.8.1
   source + target changed to 11
Kotlin version updated to 1.5.10 (artifactId:kotlin-stdlib-jdk8)